### PR TITLE
Fix bug: Wrong tag sorting

### DIFF
--- a/src/simcore_service_deployment_agent/git_url_watcher.py
+++ b/src/simcore_service_deployment_agent/git_url_watcher.py
@@ -139,6 +139,8 @@ async def _git_get_current_matching_tag(directory: Path, regexp: str) -> List[st
     ]  # | grep --perl-regexp --only-matching "(?<=$(git rev-parse HEAD) refs/tags/){reg}"']
     all_tags = await run_cmd_line(cmd, str(directory))
     all_tags = all_tags.split("\n")
+    print("all_tags:")
+    print(all_tags)
 
     cmd2 = ["git", "rev-parse", "HEAD"]
     shaToBeFound = await run_cmd_line(cmd2, str(directory))

--- a/src/simcore_service_deployment_agent/git_url_watcher.py
+++ b/src/simcore_service_deployment_agent/git_url_watcher.py
@@ -115,7 +115,8 @@ async def _git_get_latest_matching_tag(
         "git",
         "tag",
         "--list",
-        "--sort=taggerdate",
+        "--sort",
+        "-creatordate",
     ]  # | grep --extended-regexp --only-matching "{regexp}"']
     all_tags = await run_cmd_line(cmd, str(directory))
     if all_tags == None:
@@ -123,7 +124,11 @@ async def _git_get_latest_matching_tag(
     all_tags = all_tags.split("\n")
     all_tags = [tag for tag in all_tags if tag != ""]
     list_tags = [tag for tag in all_tags if re.search(regexp, tag) != None]
-    return list_tags[0] if list_tags else None
+    print("Current matching tags creatordate:")
+    print(list_tags)
+    print("Latest tag:")
+    print(list_tags[-1])
+    return list_tags[-1] if list_tags else None
 
 
 async def _git_get_current_matching_tag(directory: Path, regexp: str) -> List[str]:
@@ -151,7 +156,8 @@ async def _git_get_current_matching_tag(directory: Path, regexp: str) -> List[st
     foundMatchingTags = []
     for i in associatedTagsFound:
         foundMatchingTags += re.findall(reg, i)
-
+    print("Current matching tags:")
+    print(foundMatchingTags)
     return foundMatchingTags
 
 

--- a/src/simcore_service_deployment_agent/git_url_watcher.py
+++ b/src/simcore_service_deployment_agent/git_url_watcher.py
@@ -150,6 +150,10 @@ async def _git_get_current_matching_tag(directory: Path, regexp: str) -> List[st
     for tag in all_tags:
         if shaToBeFound in tag:
             associatedTagsFound.append(tag.split()[-1].split("/")[-1])
+    print("all_tags:")
+    print(associatedTagsFound)
+    print("regex:")
+    print(regexp)
     foundMatchingTags = []
     for i in associatedTagsFound:
         foundMatchingTags += re.findall(reg, i)

--- a/src/simcore_service_deployment_agent/git_url_watcher.py
+++ b/src/simcore_service_deployment_agent/git_url_watcher.py
@@ -121,12 +121,8 @@ async def _git_get_latest_matching_tag(
     if all_tags == None:
         return None
     all_tags = all_tags.split("\n")
-    print("latestMatching All tags:")
-    print(all_tags)
     all_tags = [tag for tag in all_tags if tag != ""]
     list_tags = [tag for tag in all_tags if re.search(regexp, tag) != None]
-    print("latestMatching Latest tag:")
-    print(list_tags[0] if list_tags else None)
     return list_tags[0] if list_tags else None
 
 
@@ -143,28 +139,18 @@ async def _git_get_current_matching_tag(directory: Path, regexp: str) -> List[st
     ]  # | grep --perl-regexp --only-matching "(?<=$(git rev-parse HEAD) refs/tags/){reg}"']
     all_tags = await run_cmd_line(cmd, str(directory))
     all_tags = all_tags.split("\n")
-    print("all_tags:")
-    print(all_tags)
 
     cmd2 = ["git", "rev-parse", "HEAD"]
     shaToBeFound = await run_cmd_line(cmd2, str(directory))
-    print("shaToBeFound")
-    print(shaToBeFound)
     shaToBeFound = shaToBeFound.split("\n")[0]
 
     associatedTagsFound = []
     for tag in all_tags:
         if shaToBeFound in tag:
             associatedTagsFound.append(tag.split()[-1].split("/")[-1])
-    print("associatedTagsFound:")
-    print(associatedTagsFound)
-    print("regex:")
-    print(regexp)
     foundMatchingTags = []
     for i in associatedTagsFound:
         foundMatchingTags += re.findall(reg, i)
-    print("Current matching tags:")
-    print(foundMatchingTags)
     return foundMatchingTags
 
 

--- a/src/simcore_service_deployment_agent/git_url_watcher.py
+++ b/src/simcore_service_deployment_agent/git_url_watcher.py
@@ -121,9 +121,11 @@ async def _git_get_latest_matching_tag(
     if all_tags == None:
         return None
     all_tags = all_tags.split("\n")
+    print("latestMatching All tags:")
+    print(all_tags)
     all_tags = [tag for tag in all_tags if tag != ""]
     list_tags = [tag for tag in all_tags if re.search(regexp, tag) != None]
-    print("Latest tag:")
+    print("latestMatching Latest tag:")
     print(list_tags[-1] if list_tags else None)
     return list_tags[-1] if list_tags else None
 

--- a/src/simcore_service_deployment_agent/git_url_watcher.py
+++ b/src/simcore_service_deployment_agent/git_url_watcher.py
@@ -144,13 +144,15 @@ async def _git_get_current_matching_tag(directory: Path, regexp: str) -> List[st
 
     cmd2 = ["git", "rev-parse", "HEAD"]
     shaToBeFound = await run_cmd_line(cmd2, str(directory))
+    print("shaToBeFound")
+    print(shaToBeFound)
     shaToBeFound = shaToBeFound.split("\n")[0]
 
     associatedTagsFound = []
     for tag in all_tags:
         if shaToBeFound in tag:
             associatedTagsFound.append(tag.split()[-1].split("/")[-1])
-    print("all_tags:")
+    print("associatedTagsFound:")
     print(associatedTagsFound)
     print("regex:")
     print(regexp)

--- a/src/simcore_service_deployment_agent/git_url_watcher.py
+++ b/src/simcore_service_deployment_agent/git_url_watcher.py
@@ -123,6 +123,8 @@ async def _git_get_latest_matching_tag(
     all_tags = all_tags.split("\n")
     all_tags = [tag for tag in all_tags if tag != ""]
     list_tags = [tag for tag in all_tags if re.search(regexp, tag) != None]
+    print("Latest tag:")
+    print(list_tags[-1] if list_tags else None)
     return list_tags[-1] if list_tags else None
 
 

--- a/src/simcore_service_deployment_agent/git_url_watcher.py
+++ b/src/simcore_service_deployment_agent/git_url_watcher.py
@@ -115,7 +115,7 @@ async def _git_get_latest_matching_tag(
         "git",
         "tag",
         "--list",
-        "--sort=-creatordate",
+        "--sort=creatordate",
     ]  # | grep --extended-regexp --only-matching "{regexp}"']
     all_tags = await run_cmd_line(cmd, str(directory))
     if all_tags == None:
@@ -126,8 +126,8 @@ async def _git_get_latest_matching_tag(
     all_tags = [tag for tag in all_tags if tag != ""]
     list_tags = [tag for tag in all_tags if re.search(regexp, tag) != None]
     print("latestMatching Latest tag:")
-    print(list_tags[-1] if list_tags else None)
-    return list_tags[-1] if list_tags else None
+    print(list_tags[0] if list_tags else None)
+    return list_tags[0] if list_tags else None
 
 
 async def _git_get_current_matching_tag(directory: Path, regexp: str) -> List[str]:

--- a/src/simcore_service_deployment_agent/git_url_watcher.py
+++ b/src/simcore_service_deployment_agent/git_url_watcher.py
@@ -115,15 +115,15 @@ async def _git_get_latest_matching_tag(
         "git",
         "tag",
         "--list",
-        "--sort=creatordate",
-    ]  # | grep --extended-regexp --only-matching "{regexp}"']
+        "--sort=creatordate",  # Sorted ascending by date
+    ]
     all_tags = await run_cmd_line(cmd, str(directory))
     if all_tags == None:
         return None
     all_tags = all_tags.split("\n")
     all_tags = [tag for tag in all_tags if tag != ""]
     list_tags = [tag for tag in all_tags if re.search(regexp, tag) != None]
-    return list_tags[0] if list_tags else None
+    return list_tags[-1] if list_tags else None
 
 
 async def _git_get_current_matching_tag(directory: Path, regexp: str) -> List[str]:

--- a/src/simcore_service_deployment_agent/git_url_watcher.py
+++ b/src/simcore_service_deployment_agent/git_url_watcher.py
@@ -115,8 +115,7 @@ async def _git_get_latest_matching_tag(
         "git",
         "tag",
         "--list",
-        "--sort",
-        "-creatordate",
+        "--sort=-creatordate",
     ]  # | grep --extended-regexp --only-matching "{regexp}"']
     all_tags = await run_cmd_line(cmd, str(directory))
     if all_tags == None:
@@ -124,10 +123,6 @@ async def _git_get_latest_matching_tag(
     all_tags = all_tags.split("\n")
     all_tags = [tag for tag in all_tags if tag != ""]
     list_tags = [tag for tag in all_tags if re.search(regexp, tag) != None]
-    print("Current matching tags creatordate:")
-    print(list_tags)
-    print("Latest tag:")
-    print(list_tags[-1])
     return list_tags[-1] if list_tags else None
 
 

--- a/tests/unit/test_git_url_watcher.py
+++ b/tests/unit/test_git_url_watcher.py
@@ -1,4 +1,3 @@
-import logging
 import subprocess
 
 # pylint:disable=wildcard-import
@@ -16,8 +15,6 @@ import pytest
 from simcore_service_deployment_agent import git_url_watcher
 from simcore_service_deployment_agent.cmd_utils import CmdLineError
 from simcore_service_deployment_agent.exceptions import ConfigurationError
-
-log = logging.getLogger(__name__)
 
 
 @pytest.fixture()
@@ -240,13 +237,6 @@ async def test_git_url_watcher_pull_only_selected_files_tags(
     # now there should be changes
     change_results = await git_watcher.check_for_changes()
     # get new sha
-    print(
-        _run_cmd(
-            'git for-each-ref --format="%(refname:short) | %(creatordate)" "refs/tags/*"',
-            cwd=git_repo_path,
-        )
-    )
-
     git_sha = _run_cmd("git rev-parse --short HEAD", cwd=git_repo_path)
     assert change_results[REPO_ID].split(":")[-1] == git_sha
 
@@ -257,7 +247,7 @@ async def test_git_url_watcher_pull_only_selected_files_tags(
         f"git tag {NEW_VALID_TAG_ON_SAME_SHA};",
         cwd=git_repo_path,
     )
-    NEW_VALID_TAG_ON_NEW_SHA = "staging_h5thvalid"
+    NEW_VALID_TAG_ON_NEW_SHA = "staging_h5thvalid"  # This name is intentionally "in between" the previous tags when alphabetically sorted
     _run_cmd(
         f"echo 'blahblah' >> theonefile.csv; git add .; git commit -m 'I modified theonefile.csv'; git tag {NEW_VALID_TAG_ON_NEW_SHA}",
         cwd=git_repo_path,

--- a/tests/unit/test_git_url_watcher.py
+++ b/tests/unit/test_git_url_watcher.py
@@ -220,6 +220,8 @@ async def test_git_url_watcher_pull_only_selected_files_tags(
     # now there should be changes
     change_results = await git_watcher.check_for_changes()
     # get new sha
+    print("change_results")
+    print(change_results)
     git_sha = _run_cmd("git rev-parse --short HEAD", cwd=git_repo_path)
     assert change_results == {REPO_ID: f"{REPO_ID}:{BRANCH}:{NEW_VALID_TAG}:{git_sha}"}
 

--- a/tests/unit/test_git_url_watcher.py
+++ b/tests/unit/test_git_url_watcher.py
@@ -253,7 +253,7 @@ async def test_git_url_watcher_pull_only_selected_files_tags(
         cwd=git_repo_path,
     )
     time.sleep(1.1)
-    # we should have no change here
+    # we should have a change here
     change_results = await git_watcher.check_for_changes()
     latestTag = await git_url_watcher._git_get_latest_matching_tag(
         git_watcher.watched_repos[0].directory, git_watcher.watched_repos[0].tags

--- a/tests/unit/test_git_url_watcher.py
+++ b/tests/unit/test_git_url_watcher.py
@@ -214,7 +214,7 @@ async def test_git_url_watcher_pull_only_selected_files_tags(
 
     NEW_VALID_TAG = "staging_g2ndvalid"
     _run_cmd(
-        f"git tag {NEW_VALID_TAG};",
+        f"git tag {NEW_VALID_TAG}; sleep 2",
         cwd=git_repo_path,
     )
     # now there should be changes

--- a/tests/unit/test_git_url_watcher.py
+++ b/tests/unit/test_git_url_watcher.py
@@ -236,4 +236,12 @@ async def test_git_url_watcher_pull_only_selected_files_tags(
         REPO_ID: f"{REPO_ID}:{BRANCH}:{NEW_VALID_TAG_ON_SAME_SHA}:{git_sha}"
     }
 
+    # Check that tags are sorted in correct order, by tag time, not alphabetically
+    assert len(git_watcher.watched_repos) == 1
+    latestTag = await git_url_watcher._git_get_latest_matching_tag(
+        git_watcher.watched_repos[0].directory, git_watcher.watched_repos[0].tags
+    )
+    print(latestTag)
+    assert latestTag == NEW_VALID_TAG_ON_SAME_SHA
+    #
     await git_watcher.cleanup()

--- a/tests/unit/test_git_url_watcher.py
+++ b/tests/unit/test_git_url_watcher.py
@@ -220,8 +220,6 @@ async def test_git_url_watcher_pull_only_selected_files_tags(
     # now there should be changes
     change_results = await git_watcher.check_for_changes()
     # get new sha
-    print("change_results")
-    print(change_results)
     git_sha = _run_cmd("git rev-parse --short HEAD", cwd=git_repo_path)
     assert change_results == {REPO_ID: f"{REPO_ID}:{BRANCH}:{NEW_VALID_TAG}:{git_sha}"}
 
@@ -243,7 +241,6 @@ async def test_git_url_watcher_pull_only_selected_files_tags(
     latestTag = await git_url_watcher._git_get_latest_matching_tag(
         git_watcher.watched_repos[0].directory, git_watcher.watched_repos[0].tags
     )
-    print(latestTag)
     assert latestTag == NEW_VALID_TAG_ON_SAME_SHA
     #
     await git_watcher.cleanup()


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->
This code fixes a bug where reg-expressions for identifying tags and releases in github were not correctly processed. A test to check for the correct behaviour was added as well.

