### PR TITLE
Fix/various & minor (Feb2023) 🚧🚧🚧

### DIFF
--- a/.github/workflows/deployment-agent.yml
+++ b/.github/workflows/deployment-agent.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   unit-test-deployment-agent:
-    timeout-minutes: 30
+    timeout-minutes: 15
     name: "[unit] deployment-agent"
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/deployment-agent.yml
+++ b/.github/workflows/deployment-agent.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   unit-test-deployment-agent:
-    timeout-minutes: 10
+    timeout-minutes: 30
     name: "[unit] deployment-agent"
     runs-on: ${{ matrix.os }}
     strategy:
@@ -64,7 +64,7 @@ jobs:
           flags: unittests #optional
 
   integration-test-deployment-agent:
-    timeout-minutes: 10
+    timeout-minutes: 30
     name: "[integration] deployment-agent"
     runs-on: ${{ matrix.os }}
     strategy:
@@ -104,7 +104,7 @@ jobs:
           flags: integrationtests #optional
 
   system-test-deployment-agent:
-    timeout-minutes: 10
+    timeout-minutes: 30
     name: "[system] deployment-agent"
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.pylintrc
+++ b/.pylintrc
@@ -466,7 +466,7 @@ min-public-methods=2
 [EXCEPTIONS]
 
 # Exceptions that will emit a warning when caught.
-overgeneral-exceptions=Exception
+overgeneral-exceptions=
 
 
 [IMPORTS]

--- a/.pylintrc
+++ b/.pylintrc
@@ -466,7 +466,7 @@ min-public-methods=2
 [EXCEPTIONS]
 
 # Exceptions that will emit a warning when caught.
-overgeneral-exceptions=
+overgeneral-exceptions=builtins.BaseException,builtins.Exception
 
 
 [IMPORTS]

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ test-dev-system test-ci-system: ## Run integration tests.
 
 test-dev: test-dev-unit test-dev-integration ## runs unit and integration tests for development (e.g. w/ pdb)
 
-test-pytest:
+test-pylint:
 	@pytest --cov=$(APP_PACKAGE_NAME) --color=yes $(CURDIR)/tests/unit -k test_run_pylint
 ## PYTHON -------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ test-dev-unit test-ci-unit: _check_venv_active ## Run unit tests.
 	# targets tests/unit folder
 	@make --no-print-directory _run-$(subst -unit,,$@) target=$(CURDIR)/tests/unit
 
-test-dev-integration test-ci-integration: ## Run integration tests.
+test-dev-integration test-ci-integration: .init-swarm _check_venv_active## Run integration tests.
 	# targets tests/integration folder using local/$(image-name):production images
 	@export DOCKER_REGISTRY=local; \
 	export DOCKER_IMAGE_TAG=production; \
@@ -129,6 +129,8 @@ test-dev-system test-ci-system: ## Run integration tests.
 
 test-dev: test-dev-unit test-dev-integration ## runs unit and integration tests for development (e.g. w/ pdb)
 
+test-pytest:
+	@pytest --cov=$(APP_PACKAGE_NAME) --color=yes $(CURDIR)/tests/unit -k test_run_pylint
 ## PYTHON -------------------------------
 
 .PHONY: devenv devenv-all

--- a/README.md
+++ b/README.md
@@ -18,12 +18,17 @@ A sample configuration file for the auto deployment agent is visible in [here](s
 
 The auto deployment agent may be deployed locally provided a configuration file named deployment_config.yaml is provided at the same level as the Makefile. If none is provided the test-configuration will be automatically copied (which automatically deploys the simcore core platform with some default values).
 
-```bash
-make build
-cd ../portainer
-make up # deploy portainer instance
-cd ../deployment-agent
-make up
+## Run tests locally
+```
+make devenv
+. .venv/bin/activate
+make install-dev
+make test-dev-unit
 ```
 
-This will initialise a docker swarm, and a stack containing a Portainer instance, a Portainer agent and the auto-deployment agent. The auto-deployment will start by fetching the defined repositories, generate the stack file and deploy the stack file into the swarm.
+#### Run system test locally:
+```
+## Assuming docker swarm is running
+make test-dev-system
+docker stack rm deployment-agent
+```

--- a/src/simcore_service_deployment_agent/docker_registries_watcher.py
+++ b/src/simcore_service_deployment_agent/docker_registries_watcher.py
@@ -54,7 +54,7 @@ class DockerRegistriesWatcher(SubTask):
                     self.watched_repos.append({"image": image_url})
 
     async def init(self):
-        log.debug("initialising docker watcher..")
+        log.info("initialising docker watcher..")
         with docker_client(self.private_registries) as client:
             for repo in self.watched_repos:
                 try:

--- a/src/simcore_service_deployment_agent/git_url_watcher.py
+++ b/src/simcore_service_deployment_agent/git_url_watcher.py
@@ -151,10 +151,11 @@ async def _git_get_current_matching_tag(directory: str, regexp: str) -> list[str
     associatedTagsFound = []
     for tag in all_tags:
         if shaToBeFound in tag:
-            associatedTagsFound.append(tag.split()[-1].split("/")[-1])
+            associatedTagsFound.append(tag.split()[-1].split("refs/tags/")[-1])
     foundMatchingTags = []
     for i in associatedTagsFound:
-        foundMatchingTags += re.findall(reg, i)
+        if re.search(reg, i):
+            foundMatchingTags += [i]
     return foundMatchingTags
 
 

--- a/src/simcore_service_deployment_agent/git_url_watcher.py
+++ b/src/simcore_service_deployment_agent/git_url_watcher.py
@@ -140,7 +140,7 @@ async def _git_get_current_matching_tag(directory: str, regexp: str) -> list[str
         "show-ref",
         "--tags",
         "--dereference",
-    ]  # | grep --perl-regexp --only-matching "(?<=$(git rev-parse HEAD) refs/tags/){reg}"']
+    ]
     all_tags = await run_cmd_line(cmd, f"{directory}")
     all_tags = all_tags.split("\n")
 

--- a/src/simcore_service_deployment_agent/portainer.py
+++ b/src/simcore_service_deployment_agent/portainer.py
@@ -114,6 +114,8 @@ async def get_stacks_list(
 async def get_current_stack_id(
     base_url: URL, app_session: ClientSession, bearer_code: str, stack_name: str
 ) -> Optional[str]:  # pylint: disable=unsubscriptable-object
+    if stack_name.lower() != stack_name:
+        raise ConfigurationError("Docker swarm stack names must be lowercase only!")
     log.debug("getting current stack id %s", base_url)
     stacks_list = await get_stacks_list(base_url, app_session, bearer_code)
     for stack in stacks_list:

--- a/src/simcore_service_deployment_agent/portainer.py
+++ b/src/simcore_service_deployment_agent/portainer.py
@@ -40,6 +40,8 @@ async def _portainer_request(
         if resp.status == 200:
             data = await resp.json()
             return data
+        if resp.status == 204:
+            return {"content": ""}
         if resp.status == 404:
             log.error("could not find route in %s", url)
             raise ConfigurationError(

--- a/src/simcore_service_deployment_agent/portainer.py
+++ b/src/simcore_service_deployment_agent/portainer.py
@@ -117,7 +117,8 @@ async def get_current_stack_id(
     log.debug("getting current stack id %s", base_url)
     stacks_list = await get_stacks_list(base_url, app_session, bearer_code)
     for stack in stacks_list:
-        if stack_name == stack["Name"]:
+        # Portainer / Swarm stacks absolutely need to be lowercase only strings
+        if stack_name.lower() == stack["Name"].lower():
             return stack["Id"]
     return None
 
@@ -131,6 +132,8 @@ async def post_new_stack(
     stack_name: str,
     stack_cfg: ComposeSpecsDict,
 ):  # pylint: disable=too-many-arguments
+    if stack_name.lower() != stack_name:
+        raise ConfigurationError("Docker swarm stack names must be lowercase only!")
     log.debug("creating new stack %s", base_url)
     if endpoint_id < 0:
         endpoint_id = await get_first_endpoint_id(base_url, app_session, bearer_code)

--- a/src/simcore_service_deployment_agent/portainer.py
+++ b/src/simcore_service_deployment_agent/portainer.py
@@ -24,6 +24,7 @@ MAX_TIME_TO_WAIT_S = 10
     stop=stop_after_attempt(NUMBER_OF_ATTEMPS),
     wait=wait_fixed(3) + wait_random(0, MAX_TIME_TO_WAIT_S),
     before_sleep=before_sleep_log(log, logging.WARNING),
+    reraise=True,
 )
 async def _portainer_request(
     url: URL, app_session: ClientSession, method: str, **kwargs

--- a/tests/mocks/valid_docker_stack.yaml
+++ b/tests/mocks/valid_docker_stack.yaml
@@ -2,18 +2,19 @@ version: "3"
 
 services:
   app:
-    image: jenkins:latest
+    image: alpine:latest
     ports:
       - "8080:8080"
-    restart: always
     environment:
       ORIGINAL_ENV: "the original env"
       YET_ANOTHER_ENV: "the other original env"
     extra_hosts:
       - "original_host:243.23.23.44"
+    command: sleep 1000000
   anotherapp:
     build:
       context: ../
-    image: ubuntu
+    image: ubuntu:latest
+    command: sleep 1000000
 volumes:
   some_volume:

--- a/tests/mocks/valid_system_test_config.yaml
+++ b/tests/mocks/valid_system_test_config.yaml
@@ -49,5 +49,5 @@ main:
       endpoint_id: -1
       username: admin
       password: adminadmin
-      stack_name: master-simcore
+      stack_name: deployment_agent
   polling_interval: 15

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -38,7 +38,7 @@ def portainer_stacks(
         },
         {
             "Id": randint(1, 10),
-            "Name": faker.name().replace(" ", "").lower(),
+            "Name": faker.word().lower(),
             "Type": 1,
             "EndpointID": randint(1, 10),
         },

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -38,7 +38,7 @@ def portainer_stacks(
         },
         {
             "Id": randint(1, 10),
-            "Name": faker.name(),
+            "Name": faker.name().replace(" ", "").lower(),
             "Type": 1,
             "EndpointID": randint(1, 10),
         },

--- a/tests/unit/test_auto_deploy_task.py
+++ b/tests/unit/test_auto_deploy_task.py
@@ -177,7 +177,7 @@ async def test_add_parameters(
     assert envs["ANOTHER_TEST_ENV"] == "some other test"
 
     assert "image" in stack_cfg["services"]["app"]
-    assert "jenkins:latest" in stack_cfg["services"]["app"]["image"]
+    assert "alpine:latest" in stack_cfg["services"]["app"]["image"]
     assert "image" in stack_cfg["services"]["anotherapp"]
     assert "ubuntu" in stack_cfg["services"]["anotherapp"]["image"]
 
@@ -193,6 +193,7 @@ async def test_setup_task(
 ):
     assert client.app
     assert auto_deploy_task.TASK_NAME in client.app
+    await asyncio.sleep(1)
     while client.app["state"][auto_deploy_task.TASK_NAME] == State.STARTING:
         await asyncio.sleep(1)
     assert client.app["state"][auto_deploy_task.TASK_NAME] == State.RUNNING

--- a/tests/unit/test_docker_registries_watcher.py
+++ b/tests/unit/test_docker_registries_watcher.py
@@ -94,8 +94,8 @@ async def test_docker_registries_watcher(
     }
     change_result = await docker_watcher.check_for_changes()
     assert change_result == {
-        "jenkins:latest": "image signature changed",
-        "ubuntu": "image signature changed",
+        "alpine:latest": "image signature changed",
+        "ubuntu:latest": "image signature changed",
     }
     registry_config = valid_config["main"]["docker_private_registries"][0]
     _assert_docker_client_calls(mock_docker_client, registry_config, valid_docker_stack)
@@ -129,7 +129,7 @@ async def test_docker_registries_watcher_when_registry_fetch_fails(
     mock_docker_client.return_value.images.get_registry_data.side_effect = None
     change_result = await docker_watcher.check_for_changes()
     assert change_result == {
-        "jenkins:latest": "image signature changed",
-        "ubuntu": "image signature changed",
+        "alpine:latest": "image signature changed",
+        "ubuntu:latest": "image signature changed",
     }
     _assert_docker_client_calls(mock_docker_client, registry_config, valid_docker_stack)

--- a/tests/unit/test_portainer.py
+++ b/tests/unit/test_portainer.py
@@ -30,6 +30,20 @@ def faked_stack_name(faker: Faker) -> str:
     return str(faker.word()).lower()
 
 
+async def test_authenticate(
+    event_loop: asyncio.AbstractEventLoop,
+    valid_config: dict[str, Any],
+    portainer_service_mock: aioresponses,
+    aiohttp_client_session: ClientSession,
+    bearer_code: str,
+):
+    origin = URL(valid_config["main"]["portainer"][0]["url"])
+    received_bearer_code = await portainer.authenticate(
+        origin, aiohttp_client_session, username="testuser", password="password"
+    )
+    assert received_bearer_code == bearer_code
+
+
 async def test_first_endpoint_id(
     event_loop: asyncio.AbstractEventLoop,
     valid_config: dict[str, Any],
@@ -127,7 +141,7 @@ async def test_create_stack(
             origin,
             aiohttp_client_session,
             bearer_code=bearer_code,
-            stack_id=str(faker.pyint(min_value=1)),
+            stack_id=f"{faker.pyint(min_value=1)}",
             endpoint_id=endpoint,
             stack_cfg=valid_docker_stack,
         )

--- a/tests/unit/test_portainer.py
+++ b/tests/unit/test_portainer.py
@@ -12,9 +12,11 @@ from typing import Any
 import pytest
 from aiohttp import ClientSession
 from aioresponses.core import aioresponses
+from faker import Faker
 from yarl import URL
 
 from simcore_service_deployment_agent import portainer
+from simcore_service_deployment_agent.exceptions import ConfigurationError
 
 
 @pytest.fixture
@@ -23,18 +25,9 @@ async def aiohttp_client_session() -> AsyncIterator[ClientSession]:
         yield client
 
 
-async def test_authenticate(
-    event_loop: asyncio.AbstractEventLoop,
-    valid_config: dict[str, Any],
-    portainer_service_mock: aioresponses,
-    aiohttp_client_session: ClientSession,
-    bearer_code: str,
-):
-    origin = URL(valid_config["main"]["portainer"][0]["url"])
-    received_bearer_code = await portainer.authenticate(
-        origin, aiohttp_client_session, username="testuser", password="password"
-    )
-    assert received_bearer_code == bearer_code
+@pytest.fixture
+def faked_stack_name(faker: Faker) -> str:
+    return str(faker.word()).lower()
 
 
 async def test_first_endpoint_id(
@@ -73,6 +66,7 @@ async def test_stacks(
     aiohttp_client_session: ClientSession,
     bearer_code: str,
     portainer_stacks: dict[str, Any],
+    faked_stack_name: str,
 ):
     for portainer_cfg in valid_config["main"]["portainer"]:
         origin = URL(portainer_cfg["url"])
@@ -97,7 +91,7 @@ async def test_stacks(
             origin,
             aiohttp_client_session,
             bearer_code=bearer_code,
-            stack_name="this is a anknown name",
+            stack_name=faked_stack_name,
         )
         assert not current_stack_id
 
@@ -110,9 +104,11 @@ async def test_create_stack(
     bearer_code: str,
     portainer_stacks: dict[str, Any],
     valid_docker_stack,
+    faked_stack_name: str,
+    faker: Faker,
 ):
     swarm_id = 1
-    stack_name = "my amazing stack name"
+    stack_name = faked_stack_name
     for portainer_cfg in valid_config["main"]["portainer"]:
         origin = URL(portainer_cfg["url"])
 
@@ -131,7 +127,33 @@ async def test_create_stack(
             origin,
             aiohttp_client_session,
             bearer_code=bearer_code,
-            stack_id="1",
+            stack_id=str(faker.pyint(min_value=1)),
             endpoint_id=endpoint,
             stack_cfg=valid_docker_stack,
         )
+
+
+async def test_create_stack_fails_when_name_contains_uppercase_chars(
+    loop: asyncio.AbstractEventLoop,
+    valid_config: dict[str, Any],
+    portainer_service_mock: aioresponses,
+    aiohttp_client_session: ClientSession,
+    bearer_code: str,
+    portainer_stacks: dict[str, Any],
+    valid_docker_stack,
+):
+    swarm_id = 1
+    stack_name = "myAmazingstackname"
+    for portainer_cfg in valid_config["main"]["portainer"]:
+        origin = URL(portainer_cfg["url"])
+        endpoint = 1
+        with pytest.raises(ConfigurationError):
+            new_stack = await portainer.post_new_stack(
+                origin,
+                aiohttp_client_session,
+                bearer_code=bearer_code,
+                swarm_id=swarm_id,
+                endpoint_id=endpoint,
+                stack_name=stack_name,
+                stack_cfg=valid_docker_stack,
+            )


### PR DESCRIPTION
This is part 1 of a series of 4 subsequent PRs:
- [x] (I) https://github.com/ITISFoundation/osparc-deployment-agent/pull/154
- [ ] (II) https://github.com/ITISFoundation/osparc-deployment-agent/pull/153
- [ ] (III) https://github.com/ITISFoundation/osparc-deployment-agent/pull/155
- [ ] (IV) https://github.com/ITISFoundation/osparc-deployment-agent/pull/156





This PR brings various minor fixes in preparation for the bigger changes in subsequent PRs:
- ✨ Add `make test-pylint` target
- ♻️ Longer timeouts in github action runs
- ♻️ Remove pylint deprecation
- ♻️ Update `README.md`
- 🐛 Fix bug: Handle `204` REST return code of portainer
- 🐛 Fix bug: Slashes in tags cause issues (`git_url_watcher.py:_git_get_current_matching_tag`)
- 🐛 Fix bug: Assert that all stack names contain lower case chars only


🚧🚧🚧:
- Needs to be rolled out as new version `0.11.0` with associated other 3 PRs for osparc-deployment-agent
- Needs to be merged with https://github.com/ITISFoundation/osparc-ops-environments/pull/109
- Needs to be merged with https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/merge_requests/3